### PR TITLE
メニューと画面遷移の追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 /.pnp
 .pnp.js
 .yarn/install-state.gz
+/.idea/
 
 # testing
 /coverage

--- a/app/concept/page.tsx
+++ b/app/concept/page.tsx
@@ -1,0 +1,7 @@
+export default function Concept() {
+  return (
+    <>
+     Concept
+    </>
+  );
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -18,9 +18,6 @@
 
 body {
   color: rgb(var(--foreground-rgb));
-  background-image: url("../public/background.jpeg");
-  background-size: cover;
-  resize: both;
 }
 
 @layer utilities {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -13,6 +13,7 @@ import TwitterIcon from '@mui/icons-material/Twitter';
 import MenuIcon from '@mui/icons-material/Menu';
 import Link from "next/link";
 
+
 enum LiveStatus {
   Schedule = 0,
   Live = 1,
@@ -72,7 +73,7 @@ const TitleComponent = ({ children }: Props ) => {
 
   const menuOptions = [
     { name: "VOMS.net", link: "/" },
-    { name: "Concept", link: "" },
+    { name: "Concept", link: "concept" },
   ];
 
   const liveStatusComponent = (liveStatus: LiveStatus) => {
@@ -135,7 +136,11 @@ const TitleComponent = ({ children }: Props ) => {
 
   return (
     <>
-      <div className="h-screen w-screen">
+      <div
+        className="h-screen w-screen"
+        style={
+          { backgroundImage: "url(/background.jpeg)", backgroundSize: "cover", resize: "both" }}
+      >
         <div>
           <div className="grid grid-cols-3 gap-4">
             <div></div>
@@ -200,9 +205,7 @@ const TitleComponent = ({ children }: Props ) => {
           </TitleComponent>
         </div>
 
-        {/* TODO: メニューを実装する */}
-
-        <div className="flex  justify-center items-center">
+        <div className="flex  justify-center">
           {thumnails.map(cardComponent)}
         </div>
       </div>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -70,9 +70,9 @@ const TitleComponent = ({ children }: Props ) => {
     );
   }
 
-  const options = [
-    "Concept",
-    "Videos",
+  const menuOptions = [
+    { name: "VOMS.net", link: "/" },
+    { name: "Concept", link: "" },
   ];
 
   const liveStatusComponent = (liveStatus: LiveStatus) => {
@@ -177,11 +177,16 @@ const TitleComponent = ({ children }: Props ) => {
                   },
                 }}
               >
-                {options.map((option) => (
-                  <MenuItem key={option} selected={option === 'Pyxis'} onClick={handleClose}>
-                    {option}
-                  </MenuItem>
-                ))}
+                {
+                  menuOptions.map((option) => (
+                    <MenuItem
+                      key={option.name}
+                      onClick={handleClose}
+                    >
+                      <Link href={option.link}>{option.name}</Link>
+                    </MenuItem>
+                  ))
+                }
               </Menu>
             </div>
           </div>


### PR DESCRIPTION
Next.jsのRoute機能を使ってConcept画面に遷移できるようにした
https://nextjs.org/docs/app/building-your-application/routing/pages-and-layouts

<img width="1431" alt="image" src="https://github.com/hiroyuki-nishi/yotuber/assets/17105102/8ad10de4-67b8-4b97-9993-f63e184abb7d">
<img width="1440" alt="image" src="https://github.com/hiroyuki-nishi/yotuber/assets/17105102/e1dd3a48-c7b5-4859-8acf-85311b219da3">
